### PR TITLE
Upgrade trivy components and refresh the local patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN git config --global user.email ""
 RUN git config --global user.name "wr-trivy"
 
 # Install Go.
-ADD https://go.dev/dl/go1.23.2.linux-amd64.tar.gz ./
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz
+ADD https://go.dev/dl/go1.26.3.linux-amd64.tar.gz ./
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.3.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 RUN go version
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ There are two methods to install and run `trivy` that supports Wind River Linux.
 The docker image is 
 
 ⚠ **WARNING:** This file is written and verified for hosts running `Ubuntu 20.04 LTS` and `Ubuntu 22.04 LTS` as the operating system (OS). If the host is running any other distributions of OS, any information provided in this file might not be accurate.
-⚠ **WARNING:** Trivy (e.g. v0.56.2) requires go v1.22
+⚠ **WARNING:** Trivy (e.g. v0.71.0) requires go v1.26
 
 # Method 1: Installing and Runing `trivy` as a Binary on Host
 

--- a/patch/trivy-db/0001-feat-wrlinux-Add-Wind-River-Linux-support.patch
+++ b/patch/trivy-db/0001-feat-wrlinux-Add-Wind-River-Linux-support.patch
@@ -1,4 +1,4 @@
-From 8201d7cdf91b23dfe28f01e7526736ff5a7e299d Mon Sep 17 00:00:00 2001
+From 4058263d8b71f2ab15a980ed9f4bc579da1a1dc2 Mon Sep 17 00:00:00 2001
 From: David Reyna <David.Reyna@windriver.com>
 Date: Sun, 30 Oct 2022 19:12:50 -0400
 Subject: [PATCH] feat(wrlinux): Add Wind River Linux support
@@ -8,39 +8,39 @@ This commit was not accepted by the upstream.
 Signed-off-by: Sakib Sajal <sakib.sajal@windriver.com>
 Signed-off-by: William Lyu <William.Lyu@windriver.com>
 Signed-off-by: David Reyna <David.Reyna@windriver.com>
+Signed-off-by: Zhixiong Chi <zhixiong.chi@windriver.com>
 ---
  Makefile                                      |   2 +-
- pkg/vulnsrc/vulnerability/const.go            |   1 +
- pkg/vulnsrc/vulnerability/vulnerability.go    |   2 +-
- pkg/vulnsrc/vulnsrc.go                        |   2 +
+ pkg/vulnsrc/vulnerability/const.go            |   2 +
+ pkg/vulnsrc/vulnsrc.go                        |   3 +
  .../vuln-list/wrlinux/CVE-2020-24241.json     |  29 +++
  pkg/vulnsrc/wrlinux/types.go                  |  18 ++
  pkg/vulnsrc/wrlinux/wrlinux.go                | 207 ++++++++++++++++++
  pkg/vulnsrc/wrlinux/wrlinux_test.go           |  94 ++++++++
- 8 files changed, 353 insertions(+), 2 deletions(-)
+ 7 files changed, 354 insertions(+), 1 deletion(-)
  create mode 100644 pkg/vulnsrc/wrlinux/testdata/vuln-list/wrlinux/CVE-2020-24241.json
  create mode 100644 pkg/vulnsrc/wrlinux/types.go
  create mode 100644 pkg/vulnsrc/wrlinux/wrlinux.go
  create mode 100644 pkg/vulnsrc/wrlinux/wrlinux_test.go
 
 diff --git a/Makefile b/Makefile
-index 0582d63..e1d9aec 100644
+index 6235cc1..d0b933e 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -77,7 +77,7 @@ db-fetch-langs:
+@@ -78,7 +78,7 @@ db-fetch-langs:
  
  .PHONY: db-build
  db-build: trivy-db
--	./trivy-db build --cache-dir ./$(CACHE_DIR) --output-dir ./$(OUT_DIR) --update-interval 6h
+-	./trivy-db build --cache-dir ./$(CACHE_DIR) --output-dir ./$(OUT_DIR) --update-interval 24h
 +	./trivy-db build --cache-dir ./$(CACHE_DIR) --output-dir ./$(OUT_DIR) --update-interval 1752000h
  
  .PHONY: db-compact
- db-compact: $(GOBIN)/bbolt out/trivy.db
+ db-compact: $(GOBIN)/bbolt ./$(OUT_DIR)/trivy.db
 diff --git a/pkg/vulnsrc/vulnerability/const.go b/pkg/vulnsrc/vulnerability/const.go
-index 19fa371..521c01c 100644
+index ca5b261..90e4002 100644
 --- a/pkg/vulnsrc/vulnerability/const.go
 +++ b/pkg/vulnsrc/vulnerability/const.go
-@@ -21,6 +21,7 @@ const (
+@@ -23,6 +23,7 @@ const (
  	AzureLinux            types.SourceID = "azure"
  	CBLMariner            types.SourceID = "cbl-mariner"
  	Photon                types.SourceID = "photon"
@@ -48,24 +48,17 @@ index 19fa371..521c01c 100644
  	RubySec               types.SourceID = "ruby-advisory-db"
  	PhpSecurityAdvisories types.SourceID = "php-security-advisories"
  	NodejsSecurityWg      types.SourceID = "nodejs-security-wg"
-diff --git a/pkg/vulnsrc/vulnerability/vulnerability.go b/pkg/vulnsrc/vulnerability/vulnerability.go
-index 440a495..0b983f1 100644
---- a/pkg/vulnsrc/vulnerability/vulnerability.go
-+++ b/pkg/vulnsrc/vulnerability/vulnerability.go
-@@ -14,7 +14,7 @@ const (
- )
- 
- var (
--	sources = []types.SourceID{NVD, RedHat, Debian, Ubuntu, Alpine, Amazon, OracleOVAL, SuseCVRF, Photon,
-+	sources = []types.SourceID{NVD, RedHat, Debian, Ubuntu, Alpine, Amazon, OracleOVAL, SuseCVRF, Photon, WRLinux,
- 		ArchLinux, Alma, Rocky, CBLMariner, AzureLinux, RubySec, PhpSecurityAdvisories, NodejsSecurityWg, GHSA, GLAD, OSV, K8sVulnDB,
- 	}
- )
+@@ -79,4 +80,5 @@ var AllSourceIDs = []types.SourceID{
+ 	Echo,
+ 	MinimOS,
+ 	RootIO,
++	WRLinux,
+ }
 diff --git a/pkg/vulnsrc/vulnsrc.go b/pkg/vulnsrc/vulnsrc.go
-index eafb82c..908d62b 100644
+index 86edf2b..06df215 100644
 --- a/pkg/vulnsrc/vulnsrc.go
 +++ b/pkg/vulnsrc/vulnsrc.go
-@@ -25,6 +25,7 @@ import (
+@@ -31,6 +31,7 @@ import (
  	susecvrf "github.com/aquasecurity/trivy-db/pkg/vulnsrc/suse-cvrf"
  	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/ubuntu"
  	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/wolfi"
@@ -73,14 +66,15 @@ index eafb82c..908d62b 100644
  )
  
  type VulnSrc interface {
-@@ -56,6 +57,7 @@ var (
- 		wolfi.NewVulnSrc(),
- 		chainguard.NewVulnSrc(),
- 		bitnami.NewVulnSrc(),
-+		wrlinux.NewVulnSrc(),
+@@ -68,6 +69,8 @@ var (
+ 		rootio.NewVulnSrc(),
+ 		seal.NewVulnSrc(),
  
++		wrlinux.NewVulnSrc(),
++
  		k8svulndb.NewVulnSrc(),
  
+ 		// Language-specific packages
 diff --git a/pkg/vulnsrc/wrlinux/testdata/vuln-list/wrlinux/CVE-2020-24241.json b/pkg/vulnsrc/wrlinux/testdata/vuln-list/wrlinux/CVE-2020-24241.json
 new file mode 100644
 index 0000000..65e522a
@@ -454,5 +448,5 @@ index 0000000..371d24c
 +	}
 +}
 -- 
-2.47.0
+2.49.0
 

--- a/patch/trivy/0001-feat-wrlinux-Add-Wind-River-Linux-OS-analyzer.patch
+++ b/patch/trivy/0001-feat-wrlinux-Add-Wind-River-Linux-OS-analyzer.patch
@@ -1,29 +1,32 @@
-From 1cd7e22476bfce4999796134669d2fd615fd4c2c Mon Sep 17 00:00:00 2001
+From 369e5650082802d5af15ce79c9bb2579d23c7fc4 Mon Sep 17 00:00:00 2001
 From: David Reyna <David.Reyna@windriver.com>
 Date: Wed, 19 Oct 2022 03:51:15 -0400
-Subject: [PATCH] feat(wrlinux): Add Wind River Linux OS analyzer
+Subject: [PATCH 1/3] feat(wrlinux): Add Wind River Linux OS analyzer
 
 This commit was not accepted by the upstream.
 
 Signed-off-by: Sakib Sajal <sakib.sajal@windriver.com>
 Signed-off-by: William Lyu <William.Lyu@windriver.com>
 Signed-off-by: David Reyna <David.Reyna@windriver.com>
+Signed-off-by: Zhixiong Chi <zhixiong.chi@windriver.com>
 ---
  pkg/detector/ospkg/detect.go                  |   2 +
  .../testdata/fixtures/data-source.yaml        |  12 ++
  .../wrlinux/testdata/fixtures/invalid.yaml    |   9 +
  .../wrlinux/testdata/fixtures/wrlinux.yaml    |  13 ++
- pkg/detector/ospkg/wrlinux/wrlinux.go         | 161 ++++++++++++++++++
+ pkg/detector/ospkg/wrlinux/wrlinux.go         | 163 ++++++++++++++++++
  pkg/detector/ospkg/wrlinux/wrlinux_test.go    | 131 ++++++++++++++
  pkg/fanal/analyzer/all/import.go              |   1 +
  pkg/fanal/analyzer/const.go                   |   2 +
+ pkg/fanal/analyzer/os/release/release.go      |   2 +
  .../analyzer/os/wrlinux/testdata/invalid      |   1 +
  .../analyzer/os/wrlinux/testdata/os-release   |   5 +
  pkg/fanal/analyzer/os/wrlinux/wrlinux.go      |  77 +++++++++
  pkg/fanal/analyzer/os/wrlinux/wrlinux_test.go | 103 +++++++++++
+ pkg/fanal/analyzer/pkg/rpm/rpm.go             |   4 +-
  pkg/fanal/types/const.go                      |   1 +
  pkg/vulnerability/vulnerability.go            |   4 +
- 14 files changed, 522 insertions(+)
+ 16 files changed, 528 insertions(+), 2 deletions(-)
  create mode 100644 pkg/detector/ospkg/wrlinux/testdata/fixtures/data-source.yaml
  create mode 100644 pkg/detector/ospkg/wrlinux/testdata/fixtures/invalid.yaml
  create mode 100644 pkg/detector/ospkg/wrlinux/testdata/fixtures/wrlinux.yaml
@@ -35,10 +38,10 @@ Signed-off-by: David Reyna <David.Reyna@windriver.com>
  create mode 100644 pkg/fanal/analyzer/os/wrlinux/wrlinux_test.go
 
 diff --git a/pkg/detector/ospkg/detect.go b/pkg/detector/ospkg/detect.go
-index fedc8d31c..1e3f7c455 100644
+index 865f62f60..0d182697e 100644
 --- a/pkg/detector/ospkg/detect.go
 +++ b/pkg/detector/ospkg/detect.go
-@@ -20,6 +20,7 @@ import (
+@@ -28,6 +28,7 @@ import (
  	"github.com/aquasecurity/trivy/pkg/detector/ospkg/suse"
  	"github.com/aquasecurity/trivy/pkg/detector/ospkg/ubuntu"
  	"github.com/aquasecurity/trivy/pkg/detector/ospkg/wolfi"
@@ -46,14 +49,14 @@ index fedc8d31c..1e3f7c455 100644
  	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
  	"github.com/aquasecurity/trivy/pkg/log"
  	"github.com/aquasecurity/trivy/pkg/types"
-@@ -48,6 +49,7 @@ var (
- 		ftypes.Photon:             photon.NewScanner(),
- 		ftypes.Wolfi:              wolfi.NewScanner(),
- 		ftypes.Chainguard:         chainguard.NewScanner(),
+@@ -66,6 +67,7 @@ var (
+ 		ftypes.Echo:               echo.NewScanner(),
+ 		ftypes.MinimOS:            minimos.NewScanner(),
+ 		ftypes.CoreOS:             coreos.NewScanner(),
 +		ftypes.WRLinux:            wrlinux.NewScanner(),
  	}
- )
  
+ 	// providers dynamically generate drivers based on package information
 diff --git a/pkg/detector/ospkg/wrlinux/testdata/fixtures/data-source.yaml b/pkg/detector/ospkg/wrlinux/testdata/fixtures/data-source.yaml
 new file mode 100644
 index 000000000..11fdaf44d
@@ -108,10 +111,10 @@ index 000000000..9a5f0096f
 +            FixedVersion: "10.19.5.4"
 diff --git a/pkg/detector/ospkg/wrlinux/wrlinux.go b/pkg/detector/ospkg/wrlinux/wrlinux.go
 new file mode 100644
-index 000000000..d4478a801
+index 000000000..4600104e2
 --- /dev/null
 +++ b/pkg/detector/ospkg/wrlinux/wrlinux.go
-@@ -0,0 +1,161 @@
+@@ -0,0 +1,163 @@
 +/*
 + * Copyright (c) 2022-2024 Wind River Systems, Inc.
 + *
@@ -141,7 +144,7 @@ index 000000000..d4478a801
 +	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 +	"github.com/aquasecurity/trivy/pkg/log"
 +	"github.com/aquasecurity/trivy/pkg/types"
-+	"github.com/aquasecurity/trivy/pkg/scanner/utils"
++	"github.com/aquasecurity/trivy/pkg/scan/utils"
 +	"fmt"
 +	"strings"
 +	"strconv"
@@ -154,6 +157,8 @@ index 000000000..d4478a801
 +		"10.22": time.Date(2027, 6, 30, 23, 59, 59, 0, time.UTC),
 +		"10.23": time.Date(2028, 6, 30, 23, 59, 59, 0, time.UTC),
 +		"10.24": time.Date(2029, 6, 30, 23, 59, 59, 0, time.UTC),
++		"10.25": time.Date(2030, 6, 30, 23, 59, 59, 0, time.UTC),
++		"10.26": time.Date(2031, 6, 30, 23, 59, 59, 0, time.UTC),
 +	}
 +)
 +
@@ -411,37 +416,50 @@ index 000000000..90d895614
 +	}
 +}
 diff --git a/pkg/fanal/analyzer/all/import.go b/pkg/fanal/analyzer/all/import.go
-index 5345073fd..90e848235 100644
+index 2e5a7340c..9546eaf66 100644
 --- a/pkg/fanal/analyzer/all/import.go
 +++ b/pkg/fanal/analyzer/all/import.go
-@@ -44,6 +44,7 @@ import (
+@@ -47,6 +47,7 @@ import (
  	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os/redhatbase"
  	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os/release"
  	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os/ubuntu"
 +	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os/wrlinux"
  	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/pkg/apk"
+ 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/pkg/bottlerocket_inventory"
  	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/pkg/dpkg"
- 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/pkg/rpm"
 diff --git a/pkg/fanal/analyzer/const.go b/pkg/fanal/analyzer/const.go
-index a9733d4b6..49b1fd34e 100644
+index b13fbc6ab..6081a4e85 100644
 --- a/pkg/fanal/analyzer/const.go
 +++ b/pkg/fanal/analyzer/const.go
-@@ -26,6 +26,7 @@ const (
- 	TypeSUSE       Type = "suse"
+@@ -29,6 +29,7 @@ const (
  	TypeUbuntu     Type = "ubuntu"
  	TypeUbuntuESM  Type = "ubuntu-esm"
+ 	TypeCoreOS     Type = "coreos"
 +	TypeWRLinux    Type = "wrlinux"
  
  	// OS Package
- 	TypeApk         Type = "apk"
-@@ -163,6 +164,7 @@ var (
- 		TypeRedHatBase,
+ 	TypeApk                   Type = "apk"
+@@ -173,6 +174,7 @@ var (
  		TypeSUSE,
  		TypeUbuntu,
+ 		TypeUbuntuESM,
 +		TypeWRLinux,
  		TypeApk,
+ 		TypeBottlerocketInventory,
  		TypeDpkg,
- 		TypeDpkgLicense,
+diff --git a/pkg/fanal/analyzer/os/release/release.go b/pkg/fanal/analyzer/os/release/release.go
+index 30c572c88..4c0ab0d20 100644
+--- a/pkg/fanal/analyzer/os/release/release.go
++++ b/pkg/fanal/analyzer/os/release/release.go
+@@ -114,6 +114,8 @@ func idToOSFamily(id string) types.OSType {
+ 		return types.MinimOS
+ 	case "coreos":
+ 		return types.CoreOS
++	case "wrlinux":
++		return types.WRLinux
+ 	}
+ 	// This OS is not supported for this analyzer.
+ 	return ""
 diff --git a/pkg/fanal/analyzer/os/wrlinux/testdata/invalid b/pkg/fanal/analyzer/os/wrlinux/testdata/invalid
 new file mode 100644
 index 000000000..574c7bd1e
@@ -462,7 +480,7 @@ index 000000000..5cce85568
 +PRETTY_NAME="Wind River Linux Graphics LTS 21.20 Update 5"
 diff --git a/pkg/fanal/analyzer/os/wrlinux/wrlinux.go b/pkg/fanal/analyzer/os/wrlinux/wrlinux.go
 new file mode 100644
-index 000000000..bc090c031
+index 000000000..60cc32b68
 --- /dev/null
 +++ b/pkg/fanal/analyzer/os/wrlinux/wrlinux.go
 @@ -0,0 +1,77 @@
@@ -488,6 +506,7 @@ index 000000000..bc090c031
 +	"bufio"
 +	"context"
 +	"os"
++	"slices"
 +	"strings"
 +
 +	"golang.org/x/xerrors"
@@ -495,7 +514,6 @@ index 000000000..bc090c031
 +	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 +	fos "github.com/aquasecurity/trivy/pkg/fanal/analyzer/os"
 +	"github.com/aquasecurity/trivy/pkg/fanal/types"
-+	"github.com/aquasecurity/trivy/pkg/fanal/utils"
 +)
 +
 +func init() {
@@ -533,7 +551,7 @@ index 000000000..bc090c031
 +}
 +
 +func (a wrlinuxOSAnalyzer) Required(filePath string, _ os.FileInfo) bool {
-+	return utils.StringInSlice(filePath, requiredFiles)
++	return slices.Contains(requiredFiles, filePath)
 +}
 +
 +func (a wrlinuxOSAnalyzer) Type() analyzer.Type {
@@ -652,23 +670,39 @@ index 000000000..0bc9fa531
 +		})
 +	}
 +}
+diff --git a/pkg/fanal/analyzer/pkg/rpm/rpm.go b/pkg/fanal/analyzer/pkg/rpm/rpm.go
+index e6fa93ebe..d54f8857d 100644
+--- a/pkg/fanal/analyzer/pkg/rpm/rpm.go
++++ b/pkg/fanal/analyzer/pkg/rpm/rpm.go
+@@ -255,9 +255,9 @@ func splitFileName(filename string) (name, ver, rel string, err error) {
+ 
+ func packageProvidedByVendor(pkg *rpmdb.PackageInfo) bool {
+ 	if pkg.Vendor == "" {
+-		// Official Amazon packages may not contain `Vendor` field:
++		// Official Amazon/WRLinux packages may not contain `Vendor` field:
+ 		// https://github.com/aquasecurity/trivy/issues/5887
+-		return strings.Contains(pkg.Release, "amzn")
++		return strings.Contains(pkg.Release, "amzn") || strings.Contains(pkg.Release, "wr")
+ 	}
+ 
+ 	for _, vendor := range osVendors {
 diff --git a/pkg/fanal/types/const.go b/pkg/fanal/types/const.go
-index c304f40ba..c45990399 100644
+index 7c6cc93b4..ffc1eed34 100644
 --- a/pkg/fanal/types/const.go
 +++ b/pkg/fanal/types/const.go
-@@ -41,6 +41,7 @@ const (
- 	SLES               OSType = "suse linux enterprise server"
+@@ -47,6 +47,7 @@ const (
+ 	SLES               OSType = "sles"
  	Ubuntu             OSType = "ubuntu"
  	Wolfi              OSType = "wolfi"
 +	WRLinux            OSType = "wrlinux"
  )
  
- // Programming language dependencies
+ // HasOSPackages returns true if the OS type has OS-level packages managed by a package manager.
 diff --git a/pkg/vulnerability/vulnerability.go b/pkg/vulnerability/vulnerability.go
-index 6c1e35427..59120621d 100644
+index 9a6538446..57b5a97b4 100644
 --- a/pkg/vulnerability/vulnerability.go
 +++ b/pkg/vulnerability/vulnerability.go
-@@ -39,6 +39,10 @@ var (
+@@ -40,6 +40,10 @@ var (
  			"https://hackerone.com",
  		},
  		vulnerability.RubySec: {"https://groups.google.com"},
@@ -680,5 +714,5 @@ index 6c1e35427..59120621d 100644
  )
  
 -- 
-2.47.0
+2.49.0
 

--- a/patch/trivy/0002-feat-wrlinux-Add-SBOM-support-for-Wind-River-Linux.patch
+++ b/patch/trivy/0002-feat-wrlinux-Add-SBOM-support-for-Wind-River-Linux.patch
@@ -1,7 +1,7 @@
-From c07ba64ab87205d09a062af2dba5b67fe1937977 Mon Sep 17 00:00:00 2001
+From 5c6914fd47f6cb16b34b451310ec8ebdf6543f0a Mon Sep 17 00:00:00 2001
 From: Dapeng Yu <dapeng.yu@windriver.com>
 Date: Tue, 22 Oct 2024 18:27:47 +0800
-Subject: feat(wrlinux): Add SBOM support for Wind River Linux
+Subject: [PATCH 2/3] feat(wrlinux): Add SBOM support for Wind River Linux
 
 Signed-off-by: Dapeng Yu <dapeng.yu@windriver.com>
 ---
@@ -9,18 +9,18 @@ Signed-off-by: Dapeng Yu <dapeng.yu@windriver.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/pkg/purl/purl.go b/pkg/purl/purl.go
-index a7b1cb918..a682614ce 100644
+index d6a0ffc56..a967a2895 100644
 --- a/pkg/purl/purl.go
 +++ b/pkg/purl/purl.go
-@@ -480,7 +480,7 @@ func purlType(t ftypes.TargetType) string {
+@@ -487,7 +487,7 @@ func purlType(t ftypes.TargetType) string {
  	case ftypes.RedHat, ftypes.CentOS, ftypes.Rocky, ftypes.Alma,
  		ftypes.Amazon, ftypes.Fedora, ftypes.Oracle, ftypes.OpenSUSE,
  		ftypes.OpenSUSELeap, ftypes.OpenSUSETumbleweed, ftypes.SLES, ftypes.SLEMicro, ftypes.Photon,
--		ftypes.Azure, ftypes.CBLMariner:
-+		ftypes.Azure, ftypes.CBLMariner, ftypes.WRLinux:
+-		ftypes.Azure, ftypes.CBLMariner, ftypes.CoreOS:
++		ftypes.Azure, ftypes.CBLMariner, ftypes.CoreOS, ftypes.WRLinux:
  		return packageurl.TypeRPM
- 	case TypeOCI:
- 		return packageurl.TypeOCI
+ 	case ftypes.Bottlerocket:
+ 		return packageurlTypeBottlerocket
 -- 
-2.47.0
+2.49.0
 

--- a/patch/trivy/0003-feat-wrlinux-Add-Vendor_PR-support-for-WRLinux-LTS24.patch
+++ b/patch/trivy/0003-feat-wrlinux-Add-Vendor_PR-support-for-WRLinux-LTS24.patch
@@ -1,0 +1,139 @@
+From 8e6d577a7aad9b0f10c636c8eb80be94d363f89b Mon Sep 17 00:00:00 2001
+From: Yi Zhao <yi.zhao@windriver.com>
+Date: Thu, 6 Feb 2025 21:32:20 +0800
+Subject: [PATCH 3/3] feat(wrlinux): Add Vendor_PR support for WRLinux LTS24+
+
+For Vendor_PR-enabled releases (LTS24 and later, i.e. release >= 10.24),
+WR Trivy needs to directly compare the installed package versions against
+the recorded fix versions in the Trivy database.
+
+FixedVersion supports three formats:
+  1. RCPL format: "10.24.33.7"
+  2. PR format: "wr2402"
+  3. Mixed format: "10.24.33.7,wr2402"
+
+When PR is present and release >= 10.24, use PR-based version comparison.
+Otherwise fall back to RCPL-based comparison.
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+Signed-off-by: Zhixiong Chi <zhixiong.chi@windriver.com>
+---
+ pkg/detector/ospkg/wrlinux/wrlinux.go | 98 ++++++++++++++++++++++++++-
+ 1 file changed, 95 insertions(+), 3 deletions(-)
+
+diff --git a/pkg/detector/ospkg/wrlinux/wrlinux.go b/pkg/detector/ospkg/wrlinux/wrlinux.go
+index 4600104e2..adfbab81a 100644
+--- a/pkg/detector/ospkg/wrlinux/wrlinux.go
++++ b/pkg/detector/ospkg/wrlinux/wrlinux.go
+@@ -107,9 +107,21 @@ func (s *Scanner) Detect(ctx context.Context, osVer string, _ *ftypes.Repository
+ 				vulns = append(vulns, vuln)
+ 				continue
+ 			}
+-			if osVerLT(osVer, strings.Split(adv.FixedVersion, " ")[0]) {
+-				vuln.FixedVersion = adv.FixedVersion
+-				vulns = append(vulns, vuln)
++
++			release := OsVerToRelease(osVer)
++			prVer := extractPR(adv.FixedVersion)
++			if !osVerLT(release, "10.24") && prVer != "" {
++				// PR format or mixed format, compare using PR value
++				if pkgVerLT(vuln.InstalledVersion, prVer) {
++					vuln.FixedVersion = adv.FixedVersion
++					vulns = append(vulns, vuln)
++				}
++			} else {
++				// RCPL format or older release, use original logic
++				if osVerLT(osVer, strings.Split(adv.FixedVersion, " ")[0]) {
++					vuln.FixedVersion = adv.FixedVersion
++					vulns = append(vulns, vuln)
++				}
+ 			}
+ 		}
+ 	}
+@@ -161,3 +173,83 @@ func OsVerToRelease(osVer string) string {
+ 	}
+ 	return strings.Join(s[:2], ".")
+ }
++
++// extractPR extracts the PR portion from FixedVersion.
++// Supports three formats:
++//   "wr2402"             -> "wr2402"
++//   "10.24.33.7,wr2402"  -> "wr2402"
++//   "10.24.33.7"         -> "" (no PR)
++func extractPR(fixedVersion string) string {
++	// Mixed format: comma-separated, take the part starting with "wr"
++	if idx := strings.Index(fixedVersion, ",wr"); idx != -1 {
++		return fixedVersion[idx+1:]
++	}
++	// Pure PR format: starts with "wr"
++	if strings.HasPrefix(fixedVersion, "wr") {
++		return fixedVersion
++	}
++	// Pure RCPL format
++	return ""
++}
++
++// pkgVerLT returns true if s1 is strictly less than s2 by PR version.
++// s1 is the installed package version (e.g. "curl-8.7.1-r0.wr2404")
++// s2 is the fixed PR version (e.g. "wr2404.1")
++func pkgVerLT(s1, s2 string) bool {
++	s1PR := GetVerPR(s1)
++	s2PR := GetVerPR(s2)
++
++	s1_spl := strings.Split(s1PR, ".")
++	s2_spl := strings.Split(s2PR, ".")
++
++	a1 := SetVerArray(s1_spl)
++	a2 := SetVerArray(s2_spl)
++
++	return CompareVerArray(a1, a2)
++}
++
++// GetVerPR extracts the PR numeric portion from a version string.
++// "curl-8.7.1-r0.wr2404"  -> "2404"
++// "wr2404.1"              -> "2404.1"
++// "2404.1"                -> "2404.1"
++func GetVerPR(s string) string {
++	// Package version format: xxx.wrXXXX
++	if idx := strings.LastIndex(s, ".wr"); idx != -1 {
++		return s[idx+3:]
++	}
++	// Pure PR format: wrXXXX
++	if strings.HasPrefix(s, "wr") {
++		return s[2:]
++	}
++	return s
++}
++
++// SetVerArray puts PR version segments into a fixed-size array of 5 elements.
++// e.g. "2404.1" -> [2404, 1, 0, 0, 0]
++func SetVerArray(s []string) [5]int {
++	arr := [5]int{}
++
++	for i := range s {
++		n, err := strconv.Atoi(s[i])
++		if err != nil {
++			continue
++		}
++		arr[i] = n
++	}
++
++	return arr
++}
++
++// CompareVerArray compares two version arrays element by element.
++// Returns true if a1 < a2.
++func CompareVerArray(a1, a2 [5]int) bool {
++	for i := 0; i < 5; i++ {
++		if a1[i] < a2[i] {
++			return true
++		}
++		if a1[i] > a2[i] {
++			return false
++		}
++	}
++	return false
++}
+-- 
+2.49.0
+

--- a/patch/vuln-list-update/0001-feat-wrlinux-Add-Wind-River-Linux-vulnerability-data.patch
+++ b/patch/vuln-list-update/0001-feat-wrlinux-Add-Wind-River-Linux-vulnerability-data.patch
@@ -1,17 +1,18 @@
-From 72d6bb26797754b1b279aadbbed1253d23672511 Mon Sep 17 00:00:00 2001
+From 5f859ba0b7dcdba11ba1e3fb99b1fd1fb835222c Mon Sep 17 00:00:00 2001
 From: Sakib Sajal <sakib.sajal@windriver.com>
 Date: Thu, 17 Feb 2022 11:22:54 -0500
 Subject: [PATCH] feat(wrlinux): Add Wind River Linux vulnerability data
 
+This commit was not accepted by the upstream.
+
 Signed-off-by: Sakib Sajal <sakib.sajal@windriver.com>
 Signed-off-by: William Lyu <William.Lyu@windriver.com>
 Signed-off-by: David Reyna <David.Reyna@windriver.com>
-
-This commit was not accepted by the upstream.
+Signed-off-by: Zhixiong Chi <zhixiong.chi@windriver.com>
 ---
- .github/workflows/update.yml                  |   4 +
+ .github/workflows/update.yml                  |  11 +
  README.md                                     |   2 +-
- main.go                                       |  15 +-
+ main.go                                       |  14 +-
  wrlinux/testdata/multiple_multiline_note      |  19 ++
  wrlinux/testdata/multiple_packages            |  19 ++
  .../testdata/multiple_references_and_notes    |  22 ++
@@ -19,7 +20,7 @@ This commit was not accepted by the upstream.
  .../testdata/with_comments_and_line_breaks    |  28 ++
  wrlinux/wrlinux.go                            | 284 ++++++++++++++++++
  wrlinux/wrlinux_test.go                       | 236 +++++++++++++++
- 10 files changed, 644 insertions(+), 2 deletions(-)
+ 10 files changed, 650 insertions(+), 2 deletions(-)
  create mode 100644 wrlinux/testdata/multiple_multiline_note
  create mode 100644 wrlinux/testdata/multiple_packages
  create mode 100644 wrlinux/testdata/multiple_references_and_notes
@@ -29,38 +30,45 @@ This commit was not accepted by the upstream.
  create mode 100644 wrlinux/wrlinux_test.go
 
 diff --git a/.github/workflows/update.yml b/.github/workflows/update.yml
-index 0793deb..e9f6a4f 100644
+index 93f03a2..784fa6e 100644
 --- a/.github/workflows/update.yml
 +++ b/.github/workflows/update.yml
-@@ -87,6 +87,10 @@ jobs:
-       name: Azure Linux and CBL-Mariner Vulnerability Data
-       run: ./scripts/update.sh azure "Azure Linux and CBL-Mariner Vulnerability Data"
+@@ -247,6 +247,17 @@ jobs:
+           repository: ${{ env.VULN_LIST_DIR }}
+           commit-message: "Seal Security Data"
  
-+    - if: always()
-+      name: WindRiver CVE Tracker
-+      run: ./vuln-list-update -target wrlinux
++      - if: always()
++        name: WindRiver CVE Tracker
++        uses: ./.github/actions/update-source
++        with:
++          target: chainguard
++          client-id: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_CLIENT_ID }}
++          private-key: ${{ secrets.SA_GH_VULN_LIST_UPDATE_GH_APP_PRIVATE_KEY }}
++          owner: ${{ github.repository_owner }}
++          repository: ${{ env.VULN_LIST_DIR }}
++          commit-message: "WRLinux Security Data"
 +
-     - if: always()
-       name: OSV Database
-       run: ./scripts/update.sh osv "OSV Database"
+       - if: always()
+         name: EOL dates
+         uses: ./.github/actions/update-source
 diff --git a/README.md b/README.md
-index b32a662..2efbdc8 100644
+index 2bfbf5f..6a199d4 100644
 --- a/README.md
 +++ b/README.md
 @@ -20,7 +20,7 @@ https://github.com/aquasecurity/vuln-list/
  $ vuln-list-update -h
  Usage of vuln-list-update:
    -target string
--        update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, chainguard, azure, openeuler)
-+        update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, chainguard, azure, openeuler, wrlinux)
+-        update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, chainguard, azure, openeuler, echo, minimos, rootio, seal)
++        update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, chainguard, azure, openeuler, echo, minimos, rootio, seal, wrlinux)
    -target-branch string
      	alternative repository branch (only glad)
    -target-uri string
 diff --git a/main.go b/main.go
-index 4abc020..cc7f344 100644
+index e3b25e7..d407869 100644
 --- a/main.go
 +++ b/main.go
-@@ -35,13 +35,22 @@ import (
+@@ -35,13 +35,21 @@ import (
  	"github.com/aquasecurity/vuln-list-update/ubuntu"
  	"github.com/aquasecurity/vuln-list-update/utils"
  	"github.com/aquasecurity/vuln-list-update/wolfi"
@@ -75,18 +83,17 @@ index 4abc020..cc7f344 100644
  
  var (
  	target = flag.String("target", "", "update target (nvd, alpine, alpine-unfixed, redhat, redhat-oval, "+
- 		"redhat-csaf-vex, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, ghsa, glad, cwe, osv, mariner, kevc, wolfi, "+
--		"chainguard, azure, openeuler)")
-+		"chainguard, azure, openeuler, wrlinux)")
-+
+ 		"redhat-csaf-vex, debian, ubuntu, amazon, oracle-oval, suse-cvrf, photon, arch-linux, glad, cwe, osvdev, mariner, kevc, wolfi, "+
+-		"chainguard, azure, openeuler, echo, minimos, eoldates, rootio)")
++		"chainguard, azure, openeuler, echo, minimos, eoldates, rootio, wrlinux)")
  	vulnListDir  = flag.String("vuln-list-dir", "", "vuln-list dir")
 +	years        = flag.String("years", "", "update years (only redhat)")
  	targetUri    = flag.String("target-uri", "", "alternative repository URI (only glad)")
  	targetBranch = flag.String("target-branch", "", "alternative repository branch (only glad)")
  )
-@@ -183,6 +192,10 @@ func run() error {
- 		if err := ec.Update(); err != nil {
- 			return xerrors.Errorf("openEuler CVE update error: %w", err)
+@@ -198,6 +206,10 @@ func run() error {
+ 		if err := su.Update(); err != nil {
+ 			return xerrors.Errorf("Seal Security update error: %w", err)
  		}
 +	case "wrlinux":
 +		if err := wrlinux.Update(); err != nil {
@@ -763,5 +770,5 @@ index 0000000..8b153dc
 +	}
 +}
 -- 
-2.47.0
+2.49.0
 

--- a/setup.sh
+++ b/setup.sh
@@ -5,8 +5,8 @@
 
 # Constants
 
-VER_TRIVY="v0.56.2"
-VER_VULN_LIST_UPDATE="8b61bbff7ce6311eff2897745e37ed37a21b7d56"
+VER_TRIVY="v0.71.0"
+VER_VULN_LIST_UPDATE="fda5655297cc6531f80807619aca21649a1c01c9"
 
 # Notes:
 #   VER_TRIVY           : Desired Trivy release (ends in '.1','.2',...)
@@ -165,6 +165,9 @@ function install {
     rm -rf vendor/github.com/aquasecurity/trivy-db/
     # Set up the correct reference to trivy-db in trivy vendor.
     ln -s "$(pwd)/../$REPO_PATH_TRIVY_DB" vendor/github.com/aquasecurity/trivy-db
+    if ! grep -q "github.com/aquasecurity/trivy-db/pkg/vulnsrc/wrlinux" vendor/modules.txt; then
+        sed -i '/trivy-db\/pkg\/vulnsrc\/wolfi/a github.com/aquasecurity/trivy-db/pkg/vulnsrc/wrlinux' vendor/modules.txt
+    fi
     popd || return 1
     apply_patch "$REPO_PATH_TRIVY" "$PATCH_DIR" || return 1
     apply_patch "$REPO_PATH_VULN_LIST_UPDATE" "$PATCH_DIR" || return 1
@@ -183,7 +186,7 @@ function install {
 
     # Build trivy binary.
     pushd "$REPO_PATH_TRIVY" || return 1
-    go build -ldflags "-s -w -X=github.com/aquasecurity/trivy/pkg/version/app.ver=$(git describe --tags --always)" ./cmd/trivy
+    GOEXPERIMENT=jsonv2 go build -ldflags "-s -w -X=github.com/aquasecurity/trivy/pkg/version/app.ver=$(git describe --tags --always)" ./cmd/trivy
     popd || return 1
     if [ $phase -eq 4 ] ; then
         return


### PR DESCRIPTION
Upgrade trivy to v0.71.0, vuln-list-update to the commit fda5655, and adjust the context including the changes:
 1.Change the golang version to 1.26.3 required by trivy v0.71.0;
 2.Add the LTS25/26 EOL information;
 3.Add package release field 'wr' as official condition for WRLinux to avoid
   the skip for the WRLinux packages;
 4.Add the PR_Vendor support in the FixedVersion field in the local patch;
 5.Change trivy version and vuln-list-udpate commitid in setup.sh.

TestPlan:
PASS: docker build -t wr-trivy .
PASS: Copy trivy binary, trivy.db, metadata.json to LTS25/LTS24 target.
PASS: trivy fs / --skip-db-update